### PR TITLE
Updated outdated Forestry API causing crashes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ group= mod_group // http://maven.apache.org/guides/mini/guide-naming-conventions
 archivesBaseName = mod_name
 
 minecraft{
-	version = "${minecraft_version}-${forge_version}"
+	version = "${minecraft_version}-${forge_version}-${minecraft_version}"
 
 	replace "@ModVersion@", project.version
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,13 +5,13 @@ mod_name=More Backpacks
 minecraft_version=1.7.10
 
 #The Forge version to use. 
-forge_version=10.13.0.1187
+forge_version=10.13.4.1558
 
 #The version of RedGearCore to download and use. 
-core_version=2.1.3
+core_version=2.2.2
 
 #The version to be used in the code and for naming the .jar
-mod_version=2.2.2
+mod_version=2.2.3
 
 #group means the package that all the classes in this mod are contained in. The root of this source. Example: redgear.geocraft
 mod_group=redgear.morebackpacks

--- a/src/main/java/forestry/api/storage/IBackpackDefinition.java
+++ b/src/main/java/forestry/api/storage/IBackpackDefinition.java
@@ -1,56 +1,27 @@
-/*******************************************************************************
- * Copyright 2011-2014 SirSengir
- * 
- * This work (the API) is licensed under the "MIT" License, see LICENSE.txt for details.
- ******************************************************************************/
 package forestry.api.storage;
 
-import net.minecraft.entity.player.EntityPlayer;
+import java.util.List;
 import net.minecraft.item.ItemStack;
 
-import java.util.List;
-
-public interface IBackpackDefinition {
-
-	/**
-	 * @return A unique string identifier
-	 */
-	String getKey();
-
-	/**
-	 * @param backpack
-	 * @return Human-readable name of the backpack.
-	 */
-	String getName(ItemStack backpack);
-
-	@Deprecated
-	String getName();
-
-	/**
-	 * @return Primary colour for the backpack icon.
-	 */
-	int getPrimaryColour();
-
-	/**
-	 * @return Secondary colour for backpack icon.
-	 */
-	int getSecondaryColour();
-
-	/**
-	 * Adds an item as valid for this backpack.
-	 * 
-	 * @param validItem
-	 */
-	void addValidItem(ItemStack validItem);
-	void addValidItems(List<ItemStack> validItems);
-
-	/**
-	 * Returns true if the itemstack is a valid item for this backpack type.
-	 * 
-	 * @param player
-	 * @param itemstack
-	 * @return true if the given itemstack is valid for this backpack, false otherwise.
-	 */
-	boolean isValidItem(EntityPlayer player, ItemStack itemstack);
-
+public abstract interface IBackpackDefinition
+{
+  public abstract String getKey();
+  
+  public abstract String getName(ItemStack nameItemStack);
+  
+  public abstract int getPrimaryColour();
+  
+  public abstract int getSecondaryColour();
+  
+  public abstract void addValidItem(ItemStack nameItemStack);
+  
+  public abstract void addValidItems(List<ItemStack> nameList);
+  
+  public abstract boolean isValidItem(ItemStack nameItemStack);
 }
+
+
+/* Location:              D:\Program Files\0E Games\Minecraft\Instances\Volentus\mods\forestry_1.7.10-4.2.16.64.jar!\forestry\api\storage\IBackpackDefinition.class
+ * Java compiler version: 7 (51.0)
+ * JD-Core Version:       0.7.1
+ */

--- a/src/main/java/redgear/morebackpacks/core/BasicBackpack.java
+++ b/src/main/java/redgear/morebackpacks/core/BasicBackpack.java
@@ -80,7 +80,7 @@ public abstract class BasicBackpack implements IBackpackDefinition {
 	}
 
 	@Override
-	public boolean isValidItem(EntityPlayer player, ItemStack check) {
+	public boolean isValidItem(ItemStack check) {
 		return itemsList.contains(new SimpleItem(check));
 	}
 
@@ -103,7 +103,6 @@ public abstract class BasicBackpack implements IBackpackDefinition {
 		return unlocalname.toLowerCase();
 	}
 
-	@Override
 	public String getName() {
 		return StatCollector.translateToLocal("item.RedGear.MoreBackpacks.Backpack." + unlocalname + ".name");
 	}


### PR DESCRIPTION
Hotfix fixing crashes wtih isValidItem,
caused by More Backpacks using an outdated Forestry API.

 